### PR TITLE
Added padding to .post-meta

### DIFF
--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -980,6 +980,7 @@ body:not(.post-template) .post-title {
     font-size: 1.5rem;
     line-height: 2.2rem;
     color: #9EABB3;
+    padding: 2%;
 }
 
 .author-thumb {


### PR DESCRIPTION
I found the metadata between the post title and content was a little too close for my liking, so I added some padding. Its not much of contribution but I thought I see if you want to include it. I put some preview images below.

<img width="435" alt="screen shot 2016-04-23 at 12 31 02" src="https://cloud.githubusercontent.com/assets/8697411/14761134/5164abcc-094f-11e6-8c88-14b3444689f3.png">
<img width="458" alt="screen shot 2016-04-23 at 12 31 09" src="https://cloud.githubusercontent.com/assets/8697411/14761133/5163ec46-094f-11e6-8b71-baf7ed0d5f64.png">
