### PR TITLE
Display the displayName instead of the id of the author.

### DIFF
--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -16,9 +16,9 @@
     </a>
     {{end}}
 
-    {{/* print the shortname (id) from the details */}}
+    {{/* print the prefered display name (displayName) from the details */}}
     <a href="/author/{{$authorDetail.id}}">
-    {{- $authorDetail.id -}}
+    {{- $authorDetail.displayname -}}
     </a>
   {{else}}
     {{/* if no author details are set, just print whatever is set on the $author field */}}


### PR DESCRIPTION
This is a fix for Issue #36